### PR TITLE
Fix make install target to be compatible with mint 20.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,9 @@ USERNAME := $(shell whoami)
 install:
 	set -e
 	chmod +x ./scripts/init.sh
+    echo "PATH=$$PATH:/home/${USERNAME}/.local/bin" >> ~/.profile
 	@./scripts/init.sh ${USERNAME}
+	. /home/${USERNAME}/.installer/bin/activate
 	ansible-playbook \
 		--user ${USERNAME} \
 		--inventory inventory/hosts.yaml \


### PR DESCRIPTION
Have to add.local/bin to path and sourrce virtualenve prior to
playbook execution, as the install was in a separate shell session

Closes issue #34 #33 